### PR TITLE
Cope with a response in Date

### DIFF
--- a/lib/holidays_from_google_calendar/client.rb
+++ b/lib/holidays_from_google_calendar/client.rb
@@ -50,9 +50,11 @@ module HolidaysFromGoogleCalendar
 
     def pack_response_in_object(response, date_min, date_max)
       response.items.reduce([]) do |array, item|
+        date = item.start.date
+
         holiday = Holiday.new(
           name: item.summary,
-          date: Date.parse(item.start.date)
+          date: date.is_a?(Date) ? date : Date.parse(date)
         )
 
         if date_min <= holiday.date && holiday.date <= date_max


### PR DESCRIPTION
Newer versions of `google-api-client` return a Date object, not a string:

```rb
    @start=
     #<Google::Apis::CalendarV3::EventDateTime:0x00007fcd494a8b98
      @date=Mon, 18 Jul 2022>,

TypeError: no implicit conversion of Date into String
from /Users/naoto_omura/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/holidays_from_google_calendar-0.4.6/lib/holidays_from_google_calendar/client.rb:55:in `parse'
```

This PR is to address this error.

If you use an older version of `google-api-client` (confirmed with v0.11), you'll get the following response:

```rb
    @start=
     #<Google::Apis::CalendarV3::EventDateTime:0x00007fb74ff53850
      @date="2022-07-18">,
```

For now, let's cope with both cases.